### PR TITLE
Add omitzero support and update documentation

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -564,6 +564,12 @@ func isExported(f reflect.StructField) bool {
 	return f.PkgPath == ""
 }
 
+// isEmptyValue returns true if the value is considered "empty": for collections and strings, this means zero length,
+// while for other types it returns true if the value is the zero value for its type (using reflect.Value.IsZero).
+// This differs from reflect.Value.IsZero() in that "empty" includes zero-length slices, maps, arrays, and strings,
+// which may not be considered zero values for all use cases.
+//
+// This function is copied from the standard json library.
 func isEmptyValue(v reflect.Value) bool {
 	switch v.Kind() {
 	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:

--- a/copy.go
+++ b/copy.go
@@ -568,8 +568,6 @@ func isExported(f reflect.StructField) bool {
 // while for other types it returns true if the value is the zero value for its type (using reflect.Value.IsZero).
 // This differs from reflect.Value.IsZero() in that "empty" includes zero-length slices, maps, arrays, and strings,
 // which may not be considered zero values for all use cases.
-//
-// This function is copied from the standard json library.
 func isEmptyValue(v reflect.Value) bool {
 	switch v.Kind() {
 	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:

--- a/copy.go
+++ b/copy.go
@@ -323,8 +323,11 @@ func newDefaultOptions() *options {
 /*
 fieldInfo gets the field info according to the field's tag, or gets StructField.Name default when the field's tag is empty.
 It returns:
+
 - name: the field name (or tag name)
+
 - omitempty: true if the tag contains "omitempty"
+
 - omitzero: true if the tag contains "omitzero"
 */
 func fieldInfo(tag string, f reflect.StructField) (name string, omitempty bool, omitzero bool) {

--- a/copy_test.go
+++ b/copy_test.go
@@ -12,6 +12,64 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestStructToMap_OmitEmpty(t *testing.T) {
+	type A struct {
+		T time.Time `json:"t,omitempty"`
+		S string    `json:"s,omitempty"`
+		N int       `json:"n,omitempty"`
+		B bool      `json:"b,omitempty"`
+	}
+	zero := time.Time{}
+	src := &A{
+		T: zero,
+		S: "",
+		N: 0,
+		B: false,
+	}
+	dst := map[string]interface{}{}
+	mask := fieldmask_utils.MaskFromString("T,S,N,B")
+	err := fieldmask_utils.StructToMap(mask, src, dst, fieldmask_utils.WithTag("json"))
+	require.NoError(t, err)
+	// T should NOT be omitted (json.Marshal does not omit zero time.Time)
+	_, hasT := dst["t"]
+	assert.True(t, hasT)
+	// S, N, B should be omitted
+	_, hasS := dst["s"]
+	_, hasN := dst["n"]
+	_, hasB := dst["b"]
+	assert.False(t, hasS)
+	assert.False(t, hasN)
+	assert.False(t, hasB)
+}
+
+func TestStructToMap_OmitZero(t *testing.T) {
+	type A struct {
+		T time.Time `json:"t,omitzero"`
+		S string    `json:"s,omitzero"`
+		N int       `json:"n,omitzero"`
+		B bool      `json:"b,omitzero"`
+	}
+	zero := time.Time{}
+	src := &A{
+		T: zero,
+		S: "",
+		N: 0,
+		B: false,
+	}
+	dst := map[string]interface{}{}
+	mask := fieldmask_utils.MaskFromString("T,S,N,B")
+	err := fieldmask_utils.StructToMap(mask, src, dst, fieldmask_utils.WithTag("json"))
+	require.NoError(t, err)
+	_, hasT := dst["t"]
+	_, hasS := dst["s"]
+	_, hasN := dst["n"]
+	_, hasB := dst["b"]
+	assert.False(t, hasT)
+	assert.False(t, hasS)
+	assert.False(t, hasN)
+	assert.False(t, hasB)
+}
+
 func TestStructToStruct_SimpleStruct(t *testing.T) {
 	type A struct {
 		Field1 string


### PR DESCRIPTION
Introduce the `omitzero` tag to exclude zero values from struct serialization, while downgrading `omitempty` to exclude only empty values. Update documentation to reflect these changes.